### PR TITLE
Do proper blob to base64 conversion using FileReader

### DIFF
--- a/src/app/tab1/tab1.page.ts
+++ b/src/app/tab1/tab1.page.ts
@@ -66,15 +66,19 @@ export class Tab1Page {
             // When getting the full response body
             console.log('ordiniFilesystem.db downloaded');
             const contFile: any = event.body;
-            const base64String = btoa(contFile);
-            await Filesystem.writeFile({
-                data: base64String,
-                directory: FilesystemDirectory.Data,
-                path: 'ordiniFilesystem.db'
-            })
-            .then(() => {
-                console.log('install ordiniFilesystem OK');
-              });
+            const reader = new FileReader;
+            reader.onload = () => {
+                var base64String = reader.result as string;
+                Filesystem.writeFile({
+                  data: base64String,
+                  directory: FilesystemDirectory.Data,
+                  path: 'ordiniFilesystem.db'
+              })
+              .then(() => {
+                  console.log('install ordiniFilesystem OK');
+                });
+            };
+            reader.readAsDataURL(contFile);
             break;
         }
       },


### PR DESCRIPTION
To make `FileReader` work, first uninstall `cordova-plugin-file`. Then this change should be enough to make Capacitor's `Filesystem.writeFile` work